### PR TITLE
feat(find): 찾기 페이지 API 추가

### DIFF
--- a/api/axios.ts
+++ b/api/axios.ts
@@ -3,15 +3,47 @@ import { AxiosResponse } from 'axios'
 import { api } from '~/common/apis'
 import { API_ENCODE_KEY } from '~/common/env'
 import { getQueryString } from '~/common/utils'
-import { GetCityParams, GetCityResponse } from '~/interfaces/axios'
+import {
+  GetCitiesParams,
+  GetCitiesResponse,
+  GetDistrictsParams,
+  GetDistrictsResponse,
+  GetKindsParams,
+  GetKindsResponse,
+  GetSheltersParams,
+  GetSheltersResponse
+} from '~/interfaces/axios'
 
 const Api = {
+  Pet: {
+    getKinds: async ({ upKindCd }: GetKindsParams) => {
+      const { data } = await api.get<AxiosResponse<GetKindsResponse>>(
+        `/kind?serviceKey=${API_ENCODE_KEY}&up_kind_cd=${upKindCd}&_type=JSON`
+      )
+
+      return data
+    }
+  },
   Location: {
-    getCity: async (params: GetCityParams) => {
+    getCities: async (params: GetCitiesParams) => {
       const queryString = getQueryString({ ...params })
 
-      const { data } = await api.get<AxiosResponse<GetCityResponse>>(
+      const { data } = await api.get<AxiosResponse<GetCitiesResponse>>(
         `/sido?serviceKey=${API_ENCODE_KEY}&${queryString}&_type=json`
+      )
+
+      return data
+    },
+    getDistricts: async ({ uprCd }: GetDistrictsParams) => {
+      const { data } = await api.get<AxiosResponse<GetDistrictsResponse>>(
+        `/sigungu?serviceKey=${API_ENCODE_KEY}&upr_cd=${uprCd}&_type=json`
+      )
+
+      return data
+    },
+    getShelters: async ({ uprCd, ogrCd }: GetSheltersParams) => {
+      const { data } = await api.get<AxiosResponse<GetSheltersResponse>>(
+        `/shelter?serviceKey=${API_ENCODE_KEY}&upr_cd=${uprCd}&org_cd=${ogrCd}&_type=json`
       )
 
       return data

--- a/api/default-query.ts
+++ b/api/default-query.ts
@@ -1,0 +1,24 @@
+import { AxiosResponse } from 'axios'
+import {
+  QueryFunction,
+  QueryKey,
+  useQuery as useQueryOrigin,
+  UseQueryOptions
+} from 'react-query'
+
+export const useQuery = <R>(
+  queryKey: QueryKey,
+  queryFn: QueryFunction,
+  options:
+    | Omit<
+        UseQueryOptions<unknown, unknown, AxiosResponse<R>['data'], QueryKey>,
+        'queryKey' | 'queryFn'
+      >
+    | undefined
+) => {
+  return useQueryOrigin<unknown, unknown, AxiosResponse<R>['data'], QueryKey>(
+    queryKey,
+    queryFn,
+    options
+  )
+}

--- a/api/queries.ts
+++ b/api/queries.ts
@@ -1,18 +1,59 @@
-import { useQuery } from 'react-query'
-
 import { UseQueryParams } from '~/common/type-utils'
-import { GetCityParams } from '~/interfaces/axios'
+import {
+  GetCitiesParams,
+  GetCitiesResponse,
+  GetDistrictsParams,
+  GetDistrictsResponse,
+  GetKindsParams,
+  GetKindsResponse,
+  GetSheltersParams,
+  GetSheltersResponse
+} from '~/interfaces/axios'
 import { queryKeys } from '~/lib/config/query-key'
 
-import { Location } from './axios'
+import Api from './axios'
+import { useQuery } from './default-query'
 
-export const useGetCityQuery = ({
+export const useGetKindsQuery = ({
   params,
   options
-}: UseQueryParams<GetCityParams>) => {
-  return useQuery(
-    [queryKeys.LOCATION.GET_PETS, params],
-    () => Location.getCity(params),
+}: UseQueryParams<GetKindsParams, GetKindsResponse>) => {
+  return useQuery<GetKindsResponse>(
+    [queryKeys.PET.GET_KINDS, params],
+    () => Api.Pet.getKinds(params),
+    options
+  )
+}
+
+export const useGetCitesQuery = ({
+  params,
+  options
+}: UseQueryParams<GetCitiesParams, GetCitiesResponse>) => {
+  return useQuery<GetCitiesResponse>(
+    [queryKeys.LOCATION.GET_CITIES, params],
+    () => Api.Location.getCities(params),
+    options
+  )
+}
+
+export const useGetDistrictsQuery = ({
+  params,
+  options
+}: UseQueryParams<GetDistrictsParams, GetDistrictsResponse>) => {
+  return useQuery<GetDistrictsResponse>(
+    [queryKeys.LOCATION.GET_DISTRICTS, params],
+    () => Api.Location.getDistricts(params),
+    options
+  )
+}
+
+export const useGetSheltersQuery = ({
+  params,
+  options
+}: UseQueryParams<GetSheltersParams, GetSheltersResponse>) => {
+  return useQuery<GetSheltersResponse>(
+    [queryKeys.LOCATION.GET_SHELTERS, params],
+    () => Api.Location.getShelters(params),
     options
   )
 }

--- a/common/type-utils.ts
+++ b/common/type-utils.ts
@@ -1,4 +1,5 @@
-import { UseQueryOptions } from 'react-query'
+import { AxiosResponse } from 'axios'
+import { QueryKey, UseQueryOptions, UseQueryResult } from 'react-query'
 import { css } from 'styled-components'
 
 export type ValueOf<T> = T[keyof T]
@@ -11,11 +12,11 @@ export type StyleRecord<T extends string | number | undefined> = Record<
 export type OptionalStyleRecord<T extends string | number | undefined> =
   Partial<StyleRecord<T>>
 
-export type UseQueryParams<P> = {
+export type UseQueryParams<P, R> = {
   params: P
   options?:
     | Omit<
-        UseQueryOptions<unknown, unknown, unknown, (string | P)[]>,
+        UseQueryOptions<unknown, unknown, AxiosResponse<R>['data'], QueryKey>,
         'queryKey' | 'queryFn'
       >
     | undefined

--- a/common/types.ts
+++ b/common/types.ts
@@ -21,3 +21,14 @@ export interface Option {
   label: CommonLabel
   value: CommonValue
 }
+
+export type PublicResponse<R = unknown> = {
+  response: {
+    body: R
+    header: {
+      reqNo: number
+      resultCode: string
+      resultMsg: string
+    }
+  }
+}

--- a/components/Radio/index.tsx
+++ b/components/Radio/index.tsx
@@ -5,14 +5,13 @@ import { CommonSize } from '~/common/types'
 import { RadioWrapper } from './index.style'
 
 export interface RadioProps extends HTMLAttributes<HTMLInputElement> {
-  value: string | number | boolean
   checked?: boolean
   size?: Exclude<CommonSize, 'md' | 'lg' | 'xl'>
 }
 
 const Radio = forwardRef(
   (
-    { children, id, value, size = 'xs', checked, ...rest }: RadioProps,
+    { children, id, size = 'xs', checked, ...rest }: RadioProps,
     ref: ForwardedRef<HTMLLabelElement>
   ) => {
     return (

--- a/components/combobox/common/trigger/index.style.ts
+++ b/components/combobox/common/trigger/index.style.ts
@@ -1,7 +1,19 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
+import Icon from '~/components/icon'
 import InputBox from '~/components/Input/input-box'
+
+const triggerIconDisabled = css`
+  color: ${({ theme }) => theme.colors.zinc_400};
+  cursor: auto;
+`
 
 export const TriggerWrapper = styled(InputBox.Input)`
   border-color: ${({ theme }) => theme.colors.zinc_300};
+`
+
+export const TriggerIcon = styled(Icon)<{ disabled?: boolean }>`
+  cursor: pointer;
+
+  ${({ disabled }) => disabled && triggerIconDisabled}
 `

--- a/components/combobox/common/trigger/index.tsx
+++ b/components/combobox/common/trigger/index.tsx
@@ -1,23 +1,40 @@
-import Icon from '~/components/icon'
 import { InputProps } from '~/components/Input/common/input'
 import InputBox from '~/components/Input/input-box'
 
 import useCombobox from '../../use-combobox'
 
-import { TriggerWrapper } from './index.style'
+import { TriggerIcon, TriggerWrapper } from './index.style'
 
 export type ComboboxTriggerProps = InputProps
 
 const Trigger = (props: ComboboxTriggerProps) => {
-  const { open, setOpen } = useCombobox()
+  const { open, setOpen, selected } = useCombobox()
+
+  const openMenu = () => {
+    if (props.disabled) return
+
+    setOpen(true)
+  }
+
+  const toggleMenu = () => {
+    if (props.disabled) return
+
+    setOpen((prev) => !prev)
+  }
 
   return (
     <InputBox>
       <TriggerWrapper
+        defaultValue={selected?.label}
         rightIcon={
-          <Icon size={20} iconName={open ? 'expand_less' : 'expand_more'} />
+          <TriggerIcon
+            size={20}
+            iconName={open ? 'expand_less' : 'expand_more'}
+            onClick={toggleMenu}
+            disabled={props.disabled}
+          />
         }
-        onClick={() => setOpen(true)}
+        onClick={openMenu}
         {...props}
       />
     </InputBox>

--- a/components/icon/index.tsx
+++ b/components/icon/index.tsx
@@ -7,9 +7,9 @@ export interface IconProps extends HTMLAttributes<HTMLSpanElement> {
   iconName: string
 }
 
-const Icon = ({ iconName, ...rest }: IconProps) => {
+const Icon = ({ iconName, className, ...rest }: IconProps) => {
   return (
-    <IconWrapper className='material-symbols-outlined' {...rest}>
+    <IconWrapper className={`material-symbols-outlined ${className}`} {...rest}>
       {iconName}
     </IconWrapper>
   )

--- a/interfaces/axios.ts
+++ b/interfaces/axios.ts
@@ -2,25 +2,78 @@
  * Base
  */
 
+import { PublicResponse } from '~/common/types'
+
+interface Kind {
+  kindCd: string
+  knm: string
+}
+
 interface City {
   orgCd: string
   orgdownNm: string
 }
 
+interface District {
+  uprCd: string
+  orgCd: string
+  orgdownNm: string
+}
+
+interface Shelter {
+  careRegNo: string
+  careNm: string
+}
+
 /**
- * Location
+ * PET
  */
 
-export interface GetCityParams {
+export interface GetKindsParams {
+  upKindCd: number
+}
+
+export type GetKindsResponse = PublicResponse<{
+  items: {
+    item: Kind[]
+  }
+}>
+
+/**
+ * LOCATION
+ */
+
+export interface GetCitiesParams {
   numOfRows: number
   pageNo: number
 }
 
-export interface GetCityResponse {
+export type GetCitiesResponse = PublicResponse<{
   items: {
     item: City[]
   }
   numOfRows: number
   pageNo: number
   totalCount: number
+}>
+
+export interface GetDistrictsParams {
+  uprCd: number
 }
+
+export type GetDistrictsResponse = PublicResponse<{
+  items: {
+    item: District[]
+  }
+}>
+
+export interface GetSheltersParams {
+  uprCd: number
+  ogrCd: number
+}
+
+export type GetSheltersResponse = PublicResponse<{
+  items: {
+    item: Shelter[]
+  }
+}>

--- a/lib/config/query-key.ts
+++ b/lib/config/query-key.ts
@@ -1,5 +1,10 @@
 export const queryKeys = {
+  PET: {
+    GET_KINDS: 'getKinds'
+  },
   LOCATION: {
-    GET_PETS: 'getPets'
+    GET_CITIES: 'getCities',
+    GET_DISTRICTS: 'getDistricts',
+    GET_SHELTERS: 'getShelters'
   }
 }

--- a/lib/domain/find.ts
+++ b/lib/domain/find.ts
@@ -1,0 +1,24 @@
+/**
+ * BASE
+ */
+
+export const PET_CODE = {
+  DOG: 417000,
+  CAT: 422400,
+  OHTER: 429900
+} as const
+
+/**
+ * FIND FORM
+ */
+
+export const FIND_LIVESTOCK_LIST = [
+  { label: '개', value: PET_CODE.DOG },
+  { label: '고양이', value: PET_CODE.CAT },
+  { label: '기타', value: PET_CODE.OHTER }
+]
+
+export const FIND_NEUTERED_LIST = [
+  { label: 'O', value: true },
+  { label: 'X', value: false }
+]

--- a/pages/find/index.page.tsx
+++ b/pages/find/index.page.tsx
@@ -1,15 +1,9 @@
-import { useGetCityQuery } from '~/api/queries'
-
 import FindForm from './src/ui/find-form'
 import Header from './src/ui/header'
 import Navigation from './src/ui/navigation'
 import { FindWrapper } from './index.style'
 
 const Find = () => {
-  const { data } = useGetCityQuery({ params: { numOfRows: 3, pageNo: 1 } })
-
-  console.log(data)
-
   return (
     <FindWrapper>
       <Navigation />

--- a/pages/find/src/ui/modules/form-combobox/index.style.ts
+++ b/pages/find/src/ui/modules/form-combobox/index.style.ts
@@ -6,4 +6,6 @@ export const FormComboboxMenu = styled(Combobox.Menu)`
   position: absolute;
   top: ${({ theme }) => (theme.figure / 2) * 13}px;
   width: 100%;
+  max-height: ${({ theme }) => theme.figure * 25}px;
+  overflow-y: scroll;
 `

--- a/pages/find/src/ui/modules/form-combobox/index.tsx
+++ b/pages/find/src/ui/modules/form-combobox/index.tsx
@@ -8,11 +8,13 @@ import { FormComboboxMenu } from './index.style'
 interface FormComboboxProps extends Partial<ComboboxProps> {
   options: Option[]
   placeholder?: string
+  disabled?: boolean
 }
 
 const FormCombobox = ({
   placeholder,
   options,
+  disabled = false,
   onSelect
 }: FormComboboxProps) => {
   const [inputValue, setInputValue] = useState('')
@@ -40,6 +42,7 @@ const FormCombobox = ({
       <Combobox.Trigger
         placeholder={placeholder}
         value={inputValue}
+        disabled={disabled}
         onChange={changeInput}
       />
       {filteredOptions.length > 0 && (


### PR DESCRIPTION
## Overview

> PR에 대한 간단한 설명을 작성해주세요. 다음은 포함될 수 있는 내용들의 예시입니다.
>
> - PR에 반영되어 있는 변화는 무엇인가요?
> - 특정 소스 코드의 변화가 의도한 영역 외에 사이드 이펙트를 야기할 수 있나요? (그렇다면 커밋 메시지에도 작성해주세요 !)
> - 특정한 테스트 환경이 존재하나요? 예) 로컬 서버, 테스트 계정

- `default-query` 파일 추가
  - `use ~ Query` 커스텀 쿼리를 위한 고정 `useQuery` 추가
  - 이를 통해 파라미터와 리턴 타입 타이핑

```ts
// 사용 예시
export const useGetDistrictsQuery = ({
  params,
  options
}: UseQueryParams<GetDistrictsParams, GetDistrictsResponse>) => {
  return useQuery<GetDistrictsResponse>(
    [queryKeys.LOCATION.GET_DISTRICTS, params],
    () => Api.Location.getDistricts(params),
    options
  )
}
```

- `interface/axios.ts` 파일 추가
  - Axios 요청 타입을 정리하고자 추가
  - 도메인 별 분리 관련된 사항은 논의 필요
- `Combobox` 컴포넌트의 `disabled` 상태 정의
  - `disabled` 상태일 경우, 메뉴가 열리지 않고 클릭되지 않는 상태
  - `Input` 의 `disabled` 상태를 정의할 필요가 있어보임

> 현재 요청 데이터가 오는 동안 드롭다운이 상태가 지연되어 선행 조건들이 선택되고 추후 요건들이 선택될 때 옵션 리스트가 늦게 생성되는 상황이 발생합니다. 이를 정적 데이터 활용으로 전환을 하던가, 로딩 상태를 만들던 등의 해결 방안이 필요해보입니다.

<br/>

## Checklist

> 해당 PR을 검증하기 위한 테스트 가이드 라인으로서 체크리스트를 작성해주세요.

- [x] 요청 성공 확인

<br/>
